### PR TITLE
Fix the params when raise an error from general functions

### DIFF
--- a/LanusStats/functions.py
+++ b/LanusStats/functions.py
@@ -420,11 +420,11 @@ def get_possible_leagues(league, season, page):
     
     possible_leagues_list = list(possible_leagues[page].keys())
     if league not in possible_leagues_list:
-        raise InvalidLeagueException('league', possible_leagues_list)
+        raise InvalidLeagueException(league, possible_leagues_list)
     
     possible_seasons_list = list(possible_leagues[page][league]['seasons'])
     if season != None and season not in possible_seasons_list:
-        raise InvalidSeasonException('league', possible_seasons_list)
+        raise InvalidSeasonException(season, possible_seasons_list)
     
     return possible_leagues
 


### PR DESCRIPTION
Para fixear el mensaje de:

League league is not valid for any of the possible leagues ['Argentina Liga Profesional',  ..... ]

y que quede por ejemplo

League NOMBRE_LIGA is not valid for any of the possible leagues ['Argentina Liga Profesional', ... ].

Lo mismo para la season