### PR TITLE
Fix UnicodeDecodeError in fbref_request caused by unicode_escape deco…

### DIFF
--- a/LanusStats/fbref.py
+++ b/LanusStats/fbref.py
@@ -333,7 +333,7 @@ class Fbref:
                 else:
                     html = result
 
-                html = html.encode("utf-8", "ignore").decode("unicode_escape")
+                html = html.encode("utf-8", "replace").decode("utf-8", "replace")
 
                 return html
 


### PR DESCRIPTION
Este PR corrige un problema de codificación que puede producir errores al obtener el HTML desde fbref_request.

Problema
--------
Actualmente el HTML devuelto por el navegador se procesa con:

html = html.encode("utf-8", "ignore").decode("unicode_escape")

Esto provoca errores al obtener los datos de los jugadores de la liga española. Código de ejemplo:

import LanusStats as ls
fbref = ls.Fbref()
    ligas_fbref = {
        'La_Liga': 'La Liga',
        'EPL': 'Premier League',
        'Bundesliga': 'Bundesliga',
        'Serie_A': 'Serie A',
        'Ligue_1': 'Ligue 1'
    }
for liga_understat, liga_fb in ligas_fbref.items():
          df_def = fbref.get_player_season_stats(stat="defense", league=liga_fb, season=temporada_fbref)

Este código anterior, genera un problema solo en la liga española, cuyo error es el siguiente:

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 12: unexpected end of data

Causa
-----
document.documentElement.outerHTML ya devuelve el HTML como una cadena válida en UTF-8 desde el navegador.

Aplicar .decode("unicode_escape") intenta interpretar el contenido como si fuera una cadena escapada de Python (con secuencias tipo \uXXXX o \xXX), lo cual no corresponde al formato real del HTML.

Esto puede provocar que caracteres multibyte (acentos, ñ, etc.) se interpreten incorrectamente o generen errores de decodificación.

Solución
--------
Se elimina el uso de unicode_escape y se normaliza la cadena de forma segura usando UTF-8:

html = html.encode("utf-8", errors="replace").decode("utf-8")

Esto evita errores de decodificación y mantiene los caracteres válidos.

Resultado
---------
- Se previenen errores UnicodeDecodeError
- Se evita la corrupción de caracteres especiales
- Se mejora la estabilidad del scraping en distintos entornos