### PR TITLE
fix: use system chromedriver in SofaScore to avoid uc version mismatch

### DIFF
--- a/LanusStats/sofascore.py
+++ b/LanusStats/sofascore.py
@@ -41,6 +41,22 @@ def _get_chrome_major_version():
             continue
     return None
 
+def _get_system_chromedriver_path():
+    """Return the path to a system-installed chromedriver, or None to let uc download its own."""
+    candidates = [
+        '/usr/local/bin/chromedriver',
+        '/usr/bin/chromedriver',
+    ]
+    for path in candidates:
+        try:
+            out = subprocess.run([path, '--version'], capture_output=True, text=True, timeout=5).stdout
+            if 'ChromeDriver' in out:
+                return path
+        except Exception:
+            continue
+    return None
+
+
 fake = Faker()
 fake.add_provider(user_agent)
 
@@ -141,7 +157,12 @@ class SofaScore:
 
         chrome_options.add_argument(f'user-agent={user_agent}')
         chrome_version = _get_chrome_major_version()
-        driver = uc.Chrome(options=chrome_options, version_main=chrome_version)
+        system_chromedriver = _get_system_chromedriver_path()
+        driver = uc.Chrome(
+            options=chrome_options,
+            version_main=chrome_version,
+            driver_executable_path=system_chromedriver,
+        )
 
         try:
             driver.get(path)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 HERE = pathlib.Path(__file__).parent
 
 
-VERSION = '2.1.3'
+VERSION = '2.1.4'
 PACKAGE_NAME = 'lanusstats'
 AUTHOR = 'Federico Rábanos'
 AUTHOR_EMAIL = 'lanusstats@gmail.com'


### PR DESCRIPTION
Add _get_system_chromedriver_path() to detect chromedriver installed by browser-actions/setup-chrome and pass it via driver_executable_path so uc.Chrome does not download a mismatched version. Bump version to 2.1.4.